### PR TITLE
close formula properly

### DIFF
--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -78,9 +78,7 @@ let fresh_var (g : env) : A.var =
 (* see ENT-EXT *)
 let rec close (g : env) (c : L.constraint_) : L.constraint_ =
   match g with
-  | E_Cons (x, (T_Refined _ as t), g') ->
-      let c' = close g' c in
-      if L.occurs_free_c x c then implication x t c' else c'
+  | E_Cons (x, (T_Refined _ as t), g') -> implication x t (close g' c)
   | _ -> c
 
 let rec check' (g : env) (e : A.expr) (ty : A.ty) : L.constraint_ =


### PR DESCRIPTION
This may actually be incorrect.
If Γ = x∶bool{x| y} then if x is not free in the predicate, then we don't add the implication and lose the information that the bool y holds.

https://github.com/mzacho/atplt2023/blob/07a5863f6983069ee84387a9f5a05799cfb54304/lib/typecheck.ml#L79-L84

What do you think? 