### PR TITLE
append

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -13,9 +13,9 @@
 %token EOF
 %left OR         /* for associative tokens: precedence increases downwards */
 %left AND
+%left EQ NEQ GE GT LE LT
 %left PLUS MINUS
 %left TIMES DIV
-%left EQ NEQ GE GT LE LT
 
 
 /* the entry points */


### PR DESCRIPTION
append fails to check with this error:

`File "lib/typecheck_test.ml", line 331, characters 0-596: append reflects len
 threw Z3.Error("Sort mismatch at argument #2 for function (declare-fun => (Bool Bool) Bool) supplied sort is Int").
`

have you seen this before @malynome?

I think the constraint should be correct (removed `True` clauses):

```
(∀xs:list. True ⇒ 
  (∀ys:list. True ⇒
    (∀xs:list. len(xs)=0 ⇒ (∀v:list. True ∧ ys=v ⇒ len(v)=len(xs)+len(ys))) ∧
    (∀hd:ℤ. True ⇒ (∀tl:list. True ⇒ 
		       (∀xs:list. len(xs)=1+len(tl) ⇒
		          (∀v:list. True ∧ tl=v ⇒ True) ∧ 
		          (∀v:list. True ∧ ys=v ⇒ True) ∧ 
		          (∀apptl:list. len(apptl)=len(tl)+len(ys) ⇒
		              (∀v:ℤ. True ∧ hd=v ⇒ True) ∧ 
		              (∀v:list. len(v)=len(tl)+len(ys) ∧ apptl=v ⇒ True) ∧ 
		              (∀v:list. len(v)=1+len(apptl) ⇒ len(v)=len(xs)+len(ys))))))))

```